### PR TITLE
feat : 로그인 여부 상태 최상단 배치 및 페이지 라우팅 일부 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,10 @@
 import styled, { createGlobalStyle } from 'styled-components';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import SideBar from './Components/UI/sidebar';
-import Main from './Pages/main';
+import SideBar from './Components/UI/Sidebar';
 import Header from './Components/UI/header';
-import Search from './Pages/search';
-import ChatSection from './Components/UI/chatSection';
-import CreatePost from './Pages/post';
+import MyPage from './Pages/mypage';
+import MainHome from './MainHome';
 
 const GlobalStyle = createGlobalStyle`
   html,
@@ -38,6 +36,20 @@ const MainContainer = styled.div`
 `;
 
 function App() {
+  const [name, setName] = useState('');
+  const [userData, setUserData] = useState(null);
+  const [isLogin, setIsLogin] = useState(false);
+
+  useEffect(() => {
+    const sessions = Object.keys(sessionStorage);
+    for (let i = 0; i < sessions.length; i += 1) {
+      if (sessions[i].includes('firebase:authUser:')) {
+        setIsLogin(true);
+        setName(JSON.parse(sessionStorage.getItem(sessions[i])).displayName);
+      }
+    }
+  }, [userData]);
+
   useEffect(() => {
     document.body.style.overflow = 'hidden';
   }, []);
@@ -45,17 +57,14 @@ function App() {
   return (
     <AppContainer>
       <GlobalStyle />
-      <Header />
+      <Header isLogin={isLogin} setUserData={setUserData} name={name} />
       <MainContainer>
         <Router>
           <SideBar />
           <Routes>
-            <Route path="/" element={<Main />} />
-            <Route path="/search" element={<Search />} />
-            <Route path="/newPost" element={<CreatePost />} />
-            {/* <Route path="/mypage" element={<MyPage />} /> */}
+            <Route path="/*" element={<MainHome />} />
+            <Route path="/mypage" element={<MyPage name={name} />} />
           </Routes>
-          <ChatSection></ChatSection>
         </Router>
       </MainContainer>
     </AppContainer>

--- a/src/Components/MyPage/userInfo.js
+++ b/src/Components/MyPage/userInfo.js
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import { ParkRounded } from '@mui/icons-material';
+
+const InfoContainer = styled.article`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  border-radius: 30px;
+  background-color: #c7d36f;
+  padding: 20px 0px;
+  svg {
+    padding: 0px 0px 0px 20px;
+  }
+`;
+const TwoLineText = styled.div`
+  display: flex;
+  flex-direction: column;
+  font-size: 22px;
+  font-weight: bold;
+  padding: 0px 15px;
+`;
+
+const UserInfo = ({ name }) => (
+  <InfoContainer>
+    <ParkRounded sx={{ fontSize: 60 }} />
+    <TwoLineText>
+      <div>안녕하세요, 나는야 고수 {name} 님!</div>
+      <div>{name} 님의 나무는 현재 4단계입니다.</div>
+    </TwoLineText>
+  </InfoContainer>
+);
+
+export default UserInfo;

--- a/src/Components/MyPage/userPostList.js
+++ b/src/Components/MyPage/userPostList.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const UserPostContainer = styled.section`
+display: flex;
+width: 100%;
+height: 100%;
+justify-content: center;
+align-items: center;
+border-radius: 0px 0px 30px 30px;
+background-color: #C7D36F;
+`
+
+const UserPostList = () => <UserPostContainer>나의 질문들</UserPostContainer>;
+
+export default UserPostList;

--- a/src/Components/MyPage/userRequestList.js
+++ b/src/Components/MyPage/userRequestList.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const UserRequestContainer = styled.section`
+display: flex;
+width: 100%;
+height: 100%;
+justify-content: center;
+align-items: center;
+border-radius: 0px 0px 30px 30px;
+background-color: #C7D36F;
+`
+
+const UserRequestList = () => <UserRequestContainer>나의 요청들</UserRequestContainer>;
+
+export default UserRequestList;

--- a/src/Components/MyPage/userTitle.js
+++ b/src/Components/MyPage/userTitle.js
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import { WhiteButton } from '../UI/button';
+
+const UserTitleContainer = styled.article`
+  display: flex;
+  flex-direction: column;
+  width: 80%;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  border-radius: 30px;
+  background-color: #c7d36f;
+  margin-right: 50px;
+  button {
+    margin-bottom: 20px;
+  }
+`;
+
+const UserTitleHeader = styled.section`
+  display: flex;
+  width: 100%;
+  height: 17%;
+  justify-content: center;
+  align-items: center;
+  font-size: 20px;
+  font-weight: 800;
+`;
+
+const UserTitleList = styled.section`
+  display: flex;
+  width: 100%;
+  height: 80%;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 130px;
+    height: 30px;
+    font-size: 18px;
+    font-weight: 600;
+    background-color: #ffffff;
+    margin: 10px;
+    padding: 8px;
+    border-radius: 30px;
+  }
+`;
+
+const titles = [
+  '나무 심기',
+  '첫 번째 나무',
+  '미니 수목원',
+  '친절의 씨앗',
+  '나는야 고수',
+  '배움의 매력',
+  '나눔의 즐거움',
+  '성장의 열정',
+  '품앗이 대장'
+];
+const usertitles = ['나무 심기', '첫 번째 나무', '미니 수목원'];
+
+const UserTitle = () => (
+  <UserTitleContainer>
+    <UserTitleHeader>나의 목패들</UserTitleHeader>
+    <UserTitleList>
+      {titles.map((el, idx) => (
+        <div key={idx} className={usertitles.includes(el) ? 'get' : ''}>
+          {el}
+        </div>
+      ))}
+    </UserTitleList>
+    <WhiteButton>목패 변경</WhiteButton>
+  </UserTitleContainer>
+);
+
+export default UserTitle;

--- a/src/Components/UI/TabMenu.js
+++ b/src/Components/UI/TabMenu.js
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+const TabSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TabButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: calc(7%);
+  button {
+    padding: 10px;
+    justify-content: center;
+    align-items: center;
+    background-color: transparent;
+    width: 100%;
+`;
+
+const TabCotentContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  height: 80%;
+`;
+
+const TabMenu = ({ tabs }) => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleTabClick = (index) => {
+    setActiveTab(index);
+  };
+
+  return (
+    <TabSection>
+      <TabButtonContainer>
+        {tabs.map((tab, index) => (
+          <button
+            key={index}
+            onClick={() => handleTabClick(index)}
+            className={activeTab === index ? 'active' : ''}
+          >
+            {tab.name}
+          </button>
+        ))}
+      </TabButtonContainer>
+      <TabCotentContainer>{tabs[activeTab].content}</TabCotentContainer>
+    </TabSection>
+  );
+};
+
+export default TabMenu;

--- a/src/Components/UI/header.js
+++ b/src/Components/UI/header.js
@@ -33,7 +33,6 @@ const ElementWrapper = styled.div`
 
 const IconWrapper = styled.div`
   margin: 0px 10px 0px 0px;
-  cursor: pointer;
 `;
 
 const LogoDetail = styled.div`
@@ -53,21 +52,7 @@ const TwoLineText = styled.div`
   font-size: 15px;
 `;
 
-const Header = () => {
-  const [name, setName] = useState('');
-  const [userData, setUserData] = useState(null);
-  const [loginState, setLoginState] = useState(false);
-
-  useEffect(() => {
-    const sessions = Object.keys(sessionStorage);
-    for (let i = 0; i < sessions.length; i += 1) {
-      if (sessions[i].includes('firebase:authUser:')) {
-        setLoginState(true);
-        setName(JSON.parse(sessionStorage.getItem(sessions[i])).displayName);
-      }
-    }
-  }, [userData]);
-
+const Header = ({ isLogin, setUserData, name }) => {
   const provider = new GoogleAuthProvider();
 
   const handleGoogleLogin = () => {
@@ -105,7 +90,7 @@ const Header = () => {
           </IconWrapper>
           <LogoDetail>나누고 나눔 받는 무한 지식 품앗이</LogoDetail>
         </ElementWrapper>
-        {loginState ? (
+        {isLogin ? (
           <ElementWrapper>
             <TwoLineText>
               <div>나는야 고수 {name} 님!</div>
@@ -114,19 +99,12 @@ const Header = () => {
             <IconWrapper>
               <ParkRounded sx={{ fontSize: 30 }} />
             </IconWrapper>
-            <IconWrapper>
-              <LogoutRounded
-                sx={{ fontSize: 30 }}
-                onClick={handleGoogleLogout}
-              />
-            </IconWrapper>
+            <LogoutRounded sx={{ fontSize: 30 }} onClick={handleGoogleLogout} />
           </ElementWrapper>
         ) : (
           <ElementWrapper>
             <OneLineText>나무와 함께 하시겠어요?</OneLineText>
-            <IconWrapper>
-              <GoogleIcon sx={{ fontSize: 30 }} onClick={handleGoogleLogin} />
-            </IconWrapper>
+            <GoogleIcon sx={{ fontSize: 30 }} onClick={handleGoogleLogin} />
           </ElementWrapper>
         )}
       </HeaderContainer>

--- a/src/MainHome.js
+++ b/src/MainHome.js
@@ -1,0 +1,20 @@
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import Main from './Pages/main';
+import Search from './Pages/search';
+import CreatePost from './Pages/post';
+import ChatSection from './Components/UI/chatSection';
+
+function MainHome() {
+  return (
+    <>
+      <Routes>
+        <Route path="/" element={<Main />} />
+        <Route path="/search" element={<Search />} />
+        <Route path="/newPost" element={<CreatePost />} />
+      </Routes>
+      <ChatSection></ChatSection>
+    </>
+  );
+}
+
+export default MainHome;

--- a/src/Pages/mypage.js
+++ b/src/Pages/mypage.js
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import UserInfo from '../Components/MyPage/userInfo';
+import UserTitle from '../Components/MyPage/userTitle';
+import UserPostList from '../Components/MyPage/userPostList';
+import UserRequestList from '../Components/MyPage/userRequestList';
+import TabMenu from '../Components/UI/TabMenu';
+
+const MyPageContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 30px;
+  width: 100%;
+  height: calc(80%);
+  background-color: #ffffff;
+  margin: 0px 20px 50px 100px;
+  padding: 20px;
+`;
+
+const ListContainer = styled.section`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 30px;
+  width: 100%;
+  height: calc(80%);
+  background-color: #ffffff;
+  padding-top: 50px;
+`;
+
+const UserList = styled.article`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 30px;
+  width: 100%;
+  height: 100%;
+  background-color: #c7d36f;
+`;
+
+const tabs = [
+  { name: '나의 요청들', content: <UserRequestList /> },
+  { name: '나의 질문들', content: <UserPostList /> }
+];
+
+const MyPage = ({ name }) => (
+  <MyPageContainer>
+    <UserInfo name={name} />
+    <ListContainer>
+      <UserTitle />
+      <UserList>
+        <TabMenu tabs={tabs} />
+      </UserList>
+    </ListContainer>
+  </MyPageContainer>
+);
+
+export default MyPage;


### PR DESCRIPTION
1. 구현 기능
* 채팅 섹션의 페이지 배치 유무에 따라 구분해 라우팅을 일부 수정했습니다.
* 로그인 상태를 최상단(App.js)에 배치해 다른 컴포넌트에서 해당 상태를 사용할 수 있도록 했습니다.
* 마이페이지를 임시 배치했습니다.

2. 논의 사항
* 마이페이지의 현재 상태는 임시 상태입니다. 빠른 시일 내에 틀을 완성해 재차 push 및 PR 올리도록 하겠습니다.
* 상태와 관련해 복잡해질 경우 로그인 상태와 관련해 상태 관리 사용 여부를 생각해도 좋을 것 같습니다.
* 해당 수정으로 인해 오류가 발생하진 않는지 확인 한 번만 부탁드립니다.