### PR TITLE
유저의 태그 리스트가 비어있을 시 컴포넌트에 0 출력되는 현상 수정 관련 PR 입니다.

### DIFF
--- a/src/Components/Post/carousel.js
+++ b/src/Components/Post/carousel.js
@@ -134,7 +134,7 @@ const Carousel = ({ tagList }) => {
   return (
     <>
       {isLoading && <GreenLoading />}
-      {!isLoading && tagList.length && (
+      {!isLoading && tagList.length ? (
         <CarouselWrapper>
           <TagWrapper>
             <p>{`# ${tagList[tagIdx]}`}</p>
@@ -158,8 +158,7 @@ const Carousel = ({ tagList }) => {
             ))}
           </Slider>
         </CarouselWrapper>
-      )}
-      {!isLoading && !tagList.length && (
+      ) : (
         <GuideWrapper>
           <div>아직 태그를 설정하지 않았어요!</div>
           <div>지금 태그를 설정하러 가볼까요?</div>


### PR DESCRIPTION
1. 구현 기능
* 유저의 태그 리스트가 비어있을 시 컴포넌트에 0 출력되는 현상의 원인 파악 후 수정

2. 논의 사항
* 더 이상 0이 출력되지 않는지 확인 부탁 드리겠습니다.
