### PR TITLE
채팅 컴포넌트 와이어프레임 구성 및 기타 오류 보수

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,9 +2,12 @@ import styled, { createGlobalStyle } from 'styled-components';
 import { useEffect } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { useRecoilValue } from 'recoil';
+import { isLoginState } from './Recoil/atoms';
 import SideBar from './Components/UI/Sidebar';
 import Header from './Components/UI/header';
 import MyPage from './Pages/mypage';
+import LoginPage from './Pages/loginPage';
 import MainHome from './MainHome';
 
 const GlobalStyle = createGlobalStyle`
@@ -39,6 +42,7 @@ const MainContainer = styled.main`
 const queryClient = new QueryClient();
 
 function App() {
+  const isLogin = useRecoilValue(isLoginState);
   useEffect(() => {
     document.body.style.overflow = 'hidden';
   }, []);
@@ -53,7 +57,10 @@ function App() {
             <SideBar />
             <Routes>
               <Route path="/*" element={<MainHome />} />
-              <Route path="/mypage" element={<MyPage />} />
+              <Route
+                path="/mypage"
+                element={isLogin ? <MyPage /> : <LoginPage />}
+              />
             </Routes>
           </Router>
         </MainContainer>

--- a/src/Components/Chat/chatList.js
+++ b/src/Components/Chat/chatList.js
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+
+const ChatListContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  border-radius: 0px 0px 30px 30px;
+  background-color: #ffffff;
+  padding: 10px 0px;
+  section {
+    width: 90%;
+    background-color: #ffffff;
+    margin: 6px;
+    padding: 6px;
+    border-bottom: 2px solid #ebebeb;
+  }
+`;
+const userChats = [
+  {
+    title: '헬프미 헬프미',
+    content: '헬프미 헬프미 헬프미',
+    createdAt: '2023.06.17'
+  },
+  {
+    title: '헬프미 헬프미',
+    content: '헬프미 헬프미 헬프미',
+    createdAt: '2023.06.17'
+  },
+  {
+    title: '헬프미 헬프미',
+    content: '헬프미 헬프미 헬프미',
+    createdAt: '2023.06.17'
+  }
+];
+
+const ChatList = ({ setIsStarted }) => (
+  <ChatListContainer>
+    {userChats.map((el, idx) => (
+      <section
+        key={idx}
+        onClick={() => {
+          setIsStarted(true);
+        }}
+      >
+        <div>{el.title}</div>
+        <div>{el.content}</div>
+        <div>{el.createdAt}</div>
+      </section>
+    ))}
+  </ChatListContainer>
+);
+
+export default ChatList;

--- a/src/Components/Chat/chatRoom.js
+++ b/src/Components/Chat/chatRoom.js
@@ -1,0 +1,109 @@
+import styled from 'styled-components';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
+import ArticleIcon from '@mui/icons-material/Article';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import InsertPhotoIcon from '@mui/icons-material/InsertPhoto';
+import TabMenu from '../UI/TabMenu';
+import ChatList from './chatList';
+import RequestList from './requestList';
+import { isStarted } from '../../Recoil/atoms';
+
+const ChatRoomContainer = styled.article`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
+const RoomHeader = styled.section`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  font-size: 17px;
+  p {
+    margin-left: 30px;
+    width: 100%;
+    text-align: left;
+  }
+`;
+const ChatMenu = styled.section`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+const Room = styled.section`
+  width: 100%;
+  height: 78%;
+  border-top: 1.5px solid #c7d36f;
+  border-bottom: 1.5px solid #c7d36f;
+`;
+const ChatInput = styled.section`
+  display: flex;
+  width: 100%;
+  height: 10%;
+  justify-content: center;
+  align-items: center;
+  svg {
+    padding: 5px;
+  }
+  input {
+    width: 85%;
+    height: 25px;
+    background-color: #efefef;
+    border-radius: 20px;
+    border: none;
+    padding: 5px 7px;
+  }
+`;
+
+const chatData = {
+  title: '도와 주십쇼',
+  postId: 5432,
+  authorId: 1234,
+  isChecked: true
+};
+
+const ChatRoom = () => {
+  const chatStarted = useRecoilValue(isStarted);
+  const setIsStarted = useSetRecoilState(isStarted);
+  const tabs = [
+    { name: '채팅', content: <ChatList setIsStarted={setIsStarted} /> },
+    { name: '요청', content: <RequestList setIsStarted={setIsStarted} /> }
+  ];
+
+  return (
+    <>
+      {chatStarted ? (
+        <ChatRoomContainer>
+          <RoomHeader>
+            <ArrowBackIosIcon
+              onClick={() => {
+                setIsStarted(false);
+              }}
+            />
+            <p>{chatData.title}</p>
+            <ChatMenu>
+              <ArticleIcon />
+              {chatData.isChecked ? (
+                <CheckBoxIcon />
+              ) : (
+                <CheckBoxOutlineBlankIcon />
+              )}
+            </ChatMenu>
+          </RoomHeader>
+          <Room></Room>
+          <ChatInput>
+            <InsertPhotoIcon />
+            <input type="text" placeholder="채팅을 입력해 주세요!" />
+          </ChatInput>
+        </ChatRoomContainer>
+      ) : (
+        <TabMenu tabs={tabs} />
+      )}
+    </>
+  );
+};
+
+export default ChatRoom;

--- a/src/Components/Chat/requestList.js
+++ b/src/Components/Chat/requestList.js
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+const ReqListContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  border-radius: 0px 0px 30px 30px;
+  background-color: #ffffff;
+  padding: 10px 0px;
+  section {
+    width: 90%;
+    background-color: #ffffff;
+    margin: 6px;
+    padding: 6px;
+    border-bottom: 2px solid #ebebeb;
+  }
+`;
+
+const requests = [
+  {
+    title: '헬프미 헬프미',
+    content: '헬프미 헬프미 헬프미',
+    createdAt: '2023.06.17'
+  },
+  {
+    title: '헬프미 헬프미',
+    content: '헬프미 헬프미 헬프미',
+    createdAt: '2023.06.17'
+  },
+  {
+    title: '헬프미 헬프미',
+    content: '헬프미 헬프미 헬프미',
+    createdAt: '2023.06.17'
+  }
+];
+
+const RequestList = ({ setIsStarted }) => (
+  <ReqListContainer>
+    {requests.map((el, idx) => (
+      <section
+        key={idx}
+        onClick={() => {
+          setIsStarted(true);
+        }}
+      >
+        <div>{el.title}</div>
+        <div>{el.content}</div>
+        <div>{el.createdAt}</div>
+      </section>
+    ))}
+  </ReqListContainer>
+);
+
+export default RequestList;

--- a/src/Components/UI/chatSection.js
+++ b/src/Components/UI/chatSection.js
@@ -1,17 +1,40 @@
 import styled from 'styled-components';
+import ChatRoom from '../Chat/chatRoom';
 
-const ChatContainer = styled.div`
+const ChatContainer = styled.article`
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
   border-radius: 30px;
   width: calc(33.33% - 30px);
   height: calc(80%);
   background-color: #ffffff;
-  margin: 0px 20px 50px 0px;
+  overflow: hidden;
+  font-weight: 600;
+  font-size: 15px;
+  margin-top: -50px;
+
+  h1 {
+    font-size: 20px;
+  }
+
+  button {
+    border-bottom: 2px solid #ebebeb;
+    font-size: 20px;
+  }
+  .active {
+    background-color: #c7d36f;
+    color: #ffffff;
+    font-weight: 800;
+    font-size: 20px;
+    border: none;
+  }
 `;
 
-const ChatSection = (props) => <ChatContainer>{props.children}</ChatContainer>;
+const ChatSection = ({ isLogin }) => (
+  <ChatContainer>
+    {isLogin ? <ChatRoom /> : <h1>나무와 함께 해야 볼 수 있어요!</h1>}
+  </ChatContainer>
+);
 
 export default ChatSection;

--- a/src/Components/UI/header.js
+++ b/src/Components/UI/header.js
@@ -28,6 +28,14 @@ const ElementWrapper = styled.article`
     font-weight: 800;
   }
 
+  .home-link {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-decoration: none;
+    color: #3f3f3f;
+  }
+
   .mypage-link {
     display: flex;
     justify-content: center;
@@ -105,10 +113,12 @@ const Header = () => {
     <>
       <HeaderContainer>
         <ElementWrapper>
-          <IconWrapper>
-            <ForestRounded sx={{ fontSize: 40 }} />
-          </IconWrapper>
-          <LogoDetail>나누고 나눔 받는 무한 지식 품앗이</LogoDetail>
+          <a href="/" className="home-link">
+            <IconWrapper>
+              <ForestRounded sx={{ fontSize: 40 }} />
+            </IconWrapper>
+            <LogoDetail>나누고 나눔 받는 무한 지식 품앗이</LogoDetail>
+          </a>
         </ElementWrapper>
         {isLogin ? (
           <ElementWrapper>

--- a/src/MainHome.js
+++ b/src/MainHome.js
@@ -50,7 +50,7 @@ function MainHome() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/*" element={<NotFound />} />
       </Routes>
-      <ChatSection></ChatSection>
+      <ChatSection isLogin={isLogin} />
     </>
   );
 }

--- a/src/Recoil/atoms.js
+++ b/src/Recoil/atoms.js
@@ -9,3 +9,8 @@ export const isLoginState = atom({
   key: 'isLoginState',
   default: false
 });
+
+export const isStarted = atom({
+  key: 'isStarted',
+  default: false
+});


### PR DESCRIPTION
1. 구현 기능
* 채팅/요청 목록 및 채팅방 와이어프레임을 구성했습니다.
* 헤더에 홈으로 이동 가능한 링크가 누락되어 연결했습니다.
* 로그인을 하지 않았을 때에도 마이페이지에 접속 가능하던 현상을 해결했습니다.

2. 논의 사항
* 채팅 컴포넌트 내에서 모달이 필요한 부분(상대방 평가, 요청 목록에서 요청 내용 확인)은 빠른 시일 내에 추가하겠습니다.
* 채팅 컴포넌트 내 페이지 전환 시 오류가 발생하지 않는지 확인 부탁드립니다.
* 헤더 홈 버튼, 마이페이지 접근 차단에서 오류가 발생하지 않는지 확인 부탁드립니다.
