### PR TITLE
목패 UI 및 기능 구현 관련 PR 입니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",
         "react-spinners": "^0.13.8",
+        "react-tooltip": "^5.18.1",
         "recoil": "^0.7.7",
         "recoil-persist": "^5.1.0",
         "styled-components": "^6.0.1",
@@ -3371,6 +3372,19 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.1.tgz",
       "integrity": "sha512-Dq5rYfEpdeel0bLVN+nfD1VWmzCkK+pJbSjIawGE+RY4+NIJqhbUDDQjvV0NUK84fMfwxvtFoCtEe70HfZjFcw=="
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
+      "integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.3.1"
+      }
     },
     "node_modules/@google-cloud/paginator": {
       "version": "4.0.1",
@@ -11352,8 +11366,7 @@
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "dev": true
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.2",
@@ -28153,6 +28166,19 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.18.1.tgz",
+      "integrity": "sha512-5zUKoMoKHTYxobzhR160+kkHdLtB+yYO8p16aQRoz2jGcOdtV0o1enNynoA4YqQb3xTjl84N8KLNoscmgMNuSg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-router-dom": "^6.14.1",
     "react-scripts": "5.0.1",
     "react-spinners": "^0.13.8",
+    "react-tooltip": "^5.18.1",
     "recoil": "^0.7.7",
     "recoil-persist": "^5.1.0",
     "styled-components": "^6.0.1",

--- a/src/Components/API/Login/fetchUser.js
+++ b/src/Components/API/Login/fetchUser.js
@@ -1,4 +1,4 @@
-import { setDoc, doc, getDoc, onSnapshot } from 'firebase/firestore';
+import { setDoc, doc, getDoc, updateDoc } from 'firebase/firestore';
 import {
   GoogleAuthProvider,
   signInWithPopup,
@@ -56,6 +56,7 @@ export const getUserData = async (userId) => {
 
     if (docSnap.exists()) {
       const userData = docSnap.data();
+
       return userData;
     } else {
       console.log('No such document!');
@@ -67,40 +68,16 @@ export const getUserData = async (userId) => {
   }
 };
 
-export const getUserBadges = async (uid) => {
+export const updateUserCurrentBadge = async (uid, badge) => {
   try {
     const docRef = doc(db, 'users', uid);
-    const docSnap = await getDoc(docRef);
+    await updateDoc(docRef, {
+      currentBadge: badge
+    });
 
-    if (docSnap.exists()) {
-      const userData = docSnap.data();
-      const { userBadges } = userData;
-
-      return userBadges;
-    } else {
-      console.log('No such document!');
-    }
+    return true;
   } catch (e) {
-    console.error('Error fetching user badges:', e);
-    throw e;
-  }
-};
-
-export const getCurrentBadge = async (uid) => {
-  try {
-    const docRef = doc(db, 'users', uid);
-    const docSnap = await getDoc(docRef);
-
-    if (docSnap.exists()) {
-      const userData = docSnap.data();
-      const { currentBadge } = userData;
-
-      return currentBadge;
-    } else {
-      console.log('No such document!');
-    }
-  } catch (e) {
-    console.error('Error fetching current user badges:', e);
+    console.error('Error updating user tags: ', e);
     throw e;
   }
 };

--- a/src/Components/MyPage/userInfo.js
+++ b/src/Components/MyPage/userInfo.js
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import { ParkRounded } from '@mui/icons-material';
 import { useRecoilValue } from 'recoil';
-import { userData } from '../../Recoil/atoms';
+import { useEffect } from 'react';
+import { userData, currentBadge } from '../../Recoil/atoms';
 
 const InfoContainer = styled.article`
   display: flex;
@@ -27,13 +28,16 @@ const TwoLineText = styled.div`
 
 function UserInfo() {
   const currentUserData = useRecoilValue(userData);
+  const selectedBadge = useRecoilValue(currentBadge);
+
+  useEffect(() => {}, [selectedBadge]);
 
   return (
     <InfoContainer>
       <ParkRounded sx={{ fontSize: 60 }} />
       <TwoLineText>
         <div>
-          안녕하세요, {currentUserData.currentBadge} {currentUserData.name} 님!
+          안녕하세요, {selectedBadge} {currentUserData.name} 님!
         </div>
         <div>
           {currentUserData.name} 님의 나무는 현재 {currentUserData.userLevel}

--- a/src/Components/MyPage/userTitle.js
+++ b/src/Components/MyPage/userTitle.js
@@ -181,7 +181,7 @@ const UserTitle = () => {
         console.error('Error updating currentBadge:', e);
         Toast.fire({
           icon: 'error',
-          title: '대표 목패가 변경에 실패하였습니다. 다시 시도해주십시오.'
+          title: '대표 목패 변경에 실패하였습니다. 다시 시도해주십시오.'
         });
       }
     });

--- a/src/Components/MyPage/userTitle.js
+++ b/src/Components/MyPage/userTitle.js
@@ -1,5 +1,13 @@
 import styled from 'styled-components';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useQuery, useMutation } from 'react-query';
+import { useEffect } from 'react';
+import { Tooltip } from 'react-tooltip';
+import Swal from 'sweetalert2';
 import { WhiteButton } from '../UI/button';
+import { userData, currentBadge } from '../../Recoil/atoms';
+import { getUserData, updateUserCurrentBadge } from '../API/Login/fetchUser';
+import { WhiteLoading } from '../UI/loading';
 
 const UserTitleContainer = styled.article`
   display: flex;
@@ -10,8 +18,9 @@ const UserTitleContainer = styled.article`
   align-items: center;
   border-radius: 30px;
   background-color: #c7d36f;
+
   button {
-    margin-bottom: 20px;
+    margin: 20px 0px 20px 0px;
   }
 `;
 
@@ -23,55 +32,190 @@ const UserTitleHeader = styled.section`
   align-items: center;
   font-size: 23px;
   font-weight: 800;
+  margin: 0 auto;
 `;
 
 const UserTitleList = styled.section`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(3, 27%);
+  margin: 0 auto;
+  grid-gap: 3%;
   width: 100%;
-  height: 80%;
-  flex-wrap: wrap;
+  height: 65%;
   justify-content: center;
   align-items: center;
+
+  .earnedBadge {
+    cursor: pointer;
+    color: #3f3f3f;
+    transform: scale(1.1);
+    transition: transform 0.2s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+    &:hover {
+      transform: scale(1.05);
+      box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+  }
+
+  .currentBadge {
+    background-color: #9eb23b;
+    color: #ffffff;
+  }
+
   div {
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 130px;
+    position: relative;
     height: 40px;
     font-size: 19px;
     font-weight: 700;
+    color: lightgray;
     background-color: #ffffff;
-    margin: 10px;
+    margin: 0px 10px 0px 10px;
     padding: 10px;
     border-radius: 30px;
+    cursor: not-allowed;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: box-shadow 0.2s ease;
+
+    &:hover {
+      &::after {
+        content: attr(data-tip);
+        position: absolute;
+        bottom: -40px;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 5px 10px 5px 10px;
+        border-radius: 5px;
+        background-color: rgba(0, 0, 0, 0.4);
+        color: #ffffff;
+        font-size: 12px;
+        max-width: 350px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
   }
 `;
 
-const titles = [
-  '나무 심기',
-  '첫 번째 나무',
-  '미니 수목원',
-  '친절의 씨앗',
-  '나는야 고수',
-  '배움의 매력',
-  '나눔의 즐거움',
-  '성장의 열정',
-  '품앗이 대장'
+const badges = [
+  { title: '나무 심기', description: '나무 첫 걸음' },
+  { title: '첫 번째 나무', description: '첫 번째 질문 글 작성 ' },
+  { title: '미니 수목원', description: '첫 번째 나무 요청' },
+  {
+    title: '친절의 씨앗',
+    description: '5번 이상 나무 요청 & 매칭 성공 기록 3회 이상'
+  },
+  {
+    title: '나는야 고수',
+    description: '5번 이상 질문 글 작성 & 매칭 성공 기록 3회 이상'
+  },
+  {
+    title: '배움의 매력',
+    description: '15번 이상 질문 글 작성 & 매칭 성공 기록 10회 이상'
+  },
+  {
+    title: '나눔의 즐거움',
+    description: '나무 평가 평점 6.5점 이상 & 매칭 성공 기록 15회 이상'
+  },
+  {
+    title: '성장의 열정',
+    description: '나무 평가 평점 8.5점 이상 & 매칭 성공 기록 25회 이상'
+  },
+  {
+    title: '품앗이 대장',
+    description: '25번 이상 질문 글 작성 & 매칭 성공 기록 20회 이상'
+  }
 ];
-const usertitles = ['나무 심기', '첫 번째 나무', '미니 수목원'];
 
-const UserTitle = () => (
-  <UserTitleContainer>
-    <UserTitleHeader>나의 목패들</UserTitleHeader>
-    <UserTitleList>
-      {titles.map((el, idx) => (
-        <div key={idx} className={usertitles.includes(el) ? 'get' : ''}>
-          {el}
-        </div>
-      ))}
-    </UserTitleList>
-    <WhiteButton>목패 변경</WhiteButton>
-  </UserTitleContainer>
-);
+const UserTitle = () => {
+  const currentUserData = useRecoilValue(userData);
+  const userId = currentUserData.uuid;
+
+  const selectedBadge = useRecoilValue(currentBadge);
+  const setSelectedBadge = useSetRecoilState(currentBadge);
+
+  useEffect(() => {}, [selectedBadge]);
+
+  const {
+    data: userTitleData,
+    isLoading,
+    refetch
+  } = useQuery('requestData', async () => {
+    const { userBadges, currentBadge } = await getUserData(userId);
+    setSelectedBadge(currentBadge);
+    return { userBadges, currentBadge };
+  });
+
+  const updateBadgeMutation = useMutation((updatedBadge) =>
+    updateUserCurrentBadge(userId, updatedBadge)
+  );
+
+  const handleClick = (idx) => {
+    setSelectedBadge(badges[idx].title);
+  };
+
+  const Toast = Swal.mixin({
+    toast: true,
+    position: 'top',
+    showConfirmButton: false,
+    timer: 3000,
+    timerProgressBar: false,
+    didOpen: (toast) => {
+      toast.addEventListener('mouseenter', Swal.stopTimer);
+      toast.addEventListener('mouseleave', Swal.resumeTimer);
+    }
+  });
+
+  const handleBadgeChange = async () => {
+    updateBadgeMutation.mutate(selectedBadge, {
+      onSuccess: () => {
+        Toast.fire({
+          icon: 'success',
+          title: '대표 목패가 변경되었습니다.'
+        });
+      },
+      onError: (e) => {
+        console.error('Error updating currentBadge:', e);
+        Toast.fire({
+          icon: 'error',
+          title: '대표 목패가 변경에 실패하였습니다. 다시 시도해주십시오.'
+        });
+      }
+    });
+  };
+
+  return (
+    <UserTitleContainer>
+      <UserTitleHeader>나의 목패들</UserTitleHeader>
+      <UserTitleList>
+        {isLoading ? (
+          <WhiteLoading />
+        ) : (
+          badges.map((el, idx) => (
+            <div
+              key={idx}
+              className={
+                userTitleData.userBadges.includes(el.title)
+                  ? el.title === selectedBadge
+                    ? 'currentBadge earnedBadge'
+                    : 'earnedBadge'
+                  : ''
+              }
+              data-tip={el.description}
+              onClick={() => handleClick(idx)}
+            >
+              {el.title}
+            </div>
+          ))
+        )}
+        <Tooltip effect="solid" place="bottom" />
+      </UserTitleList>
+      <WhiteButton onClick={handleBadgeChange}>목패 변경</WhiteButton>
+    </UserTitleContainer>
+  );
+};
 
 export default UserTitle;

--- a/src/Components/UI/header.js
+++ b/src/Components/UI/header.js
@@ -7,7 +7,7 @@ import { signOut } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
 import { useNavigate } from 'react-router-dom';
 import { auth, db } from '../../firebase';
-import { userData, isLoginState } from '../../Recoil/atoms';
+import { userData, isLoginState, currentBadge } from '../../Recoil/atoms';
 import { addUser, handleGoogleLogin } from '../API/Login/fetchUser';
 
 const HeaderContainer = styled.header`
@@ -79,8 +79,10 @@ export const sessionUserData = () => {
 const Header = () => {
   const isLogin = useRecoilValue(isLoginState);
   const currentUserData = useRecoilValue(userData);
+  const selectedBadge = useRecoilValue(currentBadge);
   const setIsLoginState = useSetRecoilState(isLoginState);
   const setUserData = useSetRecoilState(userData);
+  const setSelectedBadge = useSetRecoilState(currentBadge);
   const navigate = useNavigate();
 
   const navigateToHome = () => {
@@ -116,9 +118,12 @@ const Header = () => {
         );
       } else {
         setUserData(docSnap.data());
+        setSelectedBadge(docSnap.data().currentBadge);
       }
     }
   };
+
+  useEffect(() => {}, [selectedBadge]);
 
   useEffect(() => {
     userFunc();
@@ -148,7 +153,7 @@ const Header = () => {
           <ElementWrapper onClick={navigateToMyPage}>
             <TwoLineText>
               <div>
-                {currentUserData.currentBadge} {currentUserData.name} 님!
+                {selectedBadge} {currentUserData.name} 님!
               </div>
               <div>오늘도 좋은 하루 보내세요!</div>
             </TwoLineText>

--- a/src/Recoil/atoms.js
+++ b/src/Recoil/atoms.js
@@ -24,3 +24,8 @@ export const isStarted = atom({
   key: 'isStarted',
   default: false
 });
+
+export const currentBadge = atom({
+  key: 'currentBadge',
+  default: ''
+});


### PR DESCRIPTION
1. 구현 기능
* "나의 목패들" UI를 Grid UI로 변경
* 각 목패 item hover 시 목패 취득 기준이 보이는 tooltip 추가
* 대표 목패를 전역 데이터로 관리
* 대표 목패 변경 로직 구현

2. 논의 사항
* Grid UI 사이 간격이 넓기도 하고, 유저들이 목패 취득 조건에 대해 궁금증을 가질 수 있으므로 각 목패의 취득 기준을 보여주는 기능을 추가해보았습니다. 확인 후 피드백 부탁드립니다.
* 대표 목패는 헤더 등 다양한 컴포넌트에서 이용되므로, 이를 전역 데이터로 관리하도록 설정하였습니다. 대표 목패가 잘 변경되는지 테스트 부탁드립니다.
* 목패 취득 로직 또한 빠른 시일 내에 구현하도록 하겠습니다.
* 레벨 업 로직도 목패와 비슷한 방향으로 구현해야할 것으로 예상됩니다. 이 부분은 추후에 다시 한번 이야기 해보며 진행하면 좋을 것 같습니다.
