### PR TITLE
캐러셀 앞으로 가기/뒤로가기 버튼 로직 이슈 및 최적화 리팩토링 관련 PR 입니다.

### DIFF
--- a/src/Components/Post/carousel.js
+++ b/src/Components/Post/carousel.js
@@ -104,7 +104,7 @@ const Carousel = ({ tagList }) => {
       }
     },
     {
-      refetchInterval: 3000,
+      refetchInterval: 30000,
       refetchIntervalInBackground: true
     }
   );

--- a/src/Components/Post/carousel.js
+++ b/src/Components/Post/carousel.js
@@ -158,7 +158,7 @@ const Carousel = ({ tagList }) => {
                   carouselData[tagList[tagIdx]] &&
                   carouselData[tagList[tagIdx]].map((post, i) => (
                     <CarouselItem
-                      key={i}
+                      key={post.id}
                       title={post.title}
                       content={post.content}
                       createdAt={post.createdAt}

--- a/src/Components/Post/carousel.js
+++ b/src/Components/Post/carousel.js
@@ -131,13 +131,7 @@ const Carousel = ({ tagList }) => {
         });
       }
 
-      if (next > current) {
-        if (tagIdx < tagList.length - 1) setTagIdx((prevIdx) => prevIdx + 1);
-        else setTagIdx(0);
-      } else if (next < current) {
-        if (tagIdx > 0) setTagIdx((prevIdx) => prevIdx - 1);
-        else setTagIdx(tagList.length - 1);
-      }
+      setTagIdx(next);
     }
   };
 
@@ -152,8 +146,8 @@ const Carousel = ({ tagList }) => {
             <button onClick={handleNavigate}>태그 추가</button>
           </TagWrapper>
           <Slider ref={carouselRef} {...settings}>
-            {tagList.map((_, idx) => (
-              <CarouselItemContainer key={idx}>
+            {tagList.map((_) => (
+              <CarouselItemContainer key={tagList[tagIdx]}>
                 {carouselData &&
                   carouselData[tagList[tagIdx]] &&
                   carouselData[tagList[tagIdx]].map((post, i) => (

--- a/src/Components/Post/carouselItem.js
+++ b/src/Components/Post/carouselItem.js
@@ -1,5 +1,5 @@
 import styled, { keyframes } from 'styled-components';
-import { useState, useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DOMPurify from 'isomorphic-dompurify';
 
@@ -92,11 +92,14 @@ const Date = styled.span`
 const CarouselItem = ({ title, content, createdAt, id, isSolved }) => {
   const navigate = useNavigate();
 
-  const formattedDate = new window.Date(createdAt.seconds * 1000);
+  const formattedDate = useMemo(
+    () => new window.Date(createdAt.seconds * 1000),
+    [createdAt]
+  );
 
   const handleNavigate = useCallback(() => {
     navigate(`/posts/${id}`, { state: { isSolved } });
-  }, [id]);
+  }, [id, isSolved]);
 
   const stripHTMLTags = useCallback((html) => {
     const tmp = document.createElement('div');
@@ -105,16 +108,23 @@ const CarouselItem = ({ title, content, createdAt, id, isSolved }) => {
     return tmp.textContent || tmp.innerText || '';
   }, []);
 
-  const mergedContent = content.replace(/\n/g, '');
-  const sanitizedContent = stripHTMLTags(mergedContent);
+  const mergedContent = useMemo(() => content.replace(/\n/g, ''), [content]);
 
-  const options = {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: true
-  };
+  const sanitizedContent = useMemo(
+    () => stripHTMLTags(mergedContent),
+    [mergedContent]
+  );
+
+  const options = useMemo(
+    () => ({
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true
+    }),
+    []
+  );
 
   return (
     <ItemWrapper
@@ -149,5 +159,7 @@ const CarouselItem = ({ title, content, createdAt, id, isSolved }) => {
     </ItemWrapper>
   );
 };
+
+CarouselItem.displayName = 'CarouselItem';
 
 export default CarouselItem;

--- a/src/Components/Search/searchItem.js
+++ b/src/Components/Search/searchItem.js
@@ -85,28 +85,28 @@ const SearchItem = ({ title, content, createdAt, id, searchResult }) => {
 
   const formattedDate = new window.Date(createdAt.seconds * 1000);
 
-  const handleNavigate = useCallback(() => {
+  const handleNavigate = () => {
     navigate(`/posts/${id}`, { state: { searchResult } });
-  }, [id]);
+  };
 
-  const handleMouse = useCallback(() => {
+  const handleMouse = () => {
     setIsHovered(!isHovered);
-  }, [isHovered]);
+  };
 
-  const truncateContent = useCallback((text, maxLength) => {
+  const truncateContent = (text, maxLength) => {
     if (text.length > maxLength) {
       return `${text.slice(0, maxLength)}...`;
     }
 
     return text;
-  }, []);
+  };
 
-  const stripHTMLTags = useCallback((html) => {
+  const stripHTMLTags = (html) => {
     const tmp = document.createElement('div');
     tmp.innerHTML = html;
 
     return tmp.textContent || tmp.innerText || '';
-  }, []);
+  };
 
   const mergedContent = content.replace(/\n/g, '');
   const sanitizedContent = stripHTMLTags(mergedContent);

--- a/src/Pages/createPostPage.js
+++ b/src/Pages/createPostPage.js
@@ -62,9 +62,9 @@ const CreatePostPage = () => {
 
   const navigate = useNavigate();
 
-  const handleChange = useCallback((e) => {
+  const handleChange = (e) => {
     setTitle(e.target.value);
-  }, []);
+  };
 
   const Toast = Swal.mixin({
     toast: true,

--- a/src/Pages/editTagPage.js
+++ b/src/Pages/editTagPage.js
@@ -141,9 +141,9 @@ const EditTagPage = () => {
         />
         <SearchedTagResult>
           {searchedTagList?.length ? (
-            searchedTagList.map((el, idx) => (
+            searchedTagList.map((el) => (
               <TagItem
-                key={idx}
+                key={el.id}
                 category={el.id}
                 postCount={el.postCount}
                 tagList={tagList}

--- a/src/Pages/editTagPage.js
+++ b/src/Pages/editTagPage.js
@@ -85,7 +85,7 @@ const EditTagPage = () => {
     }
   });
 
-  const handleSave = () => {
+  const handleSave = useCallback(() => {
     if (tagList.length < 2 || !tagList.length) {
       Toast.fire({
         icon: 'error',
@@ -109,7 +109,7 @@ const EditTagPage = () => {
         }
       });
     }
-  };
+  }, [tagList]);
 
   const handleGoBack = useCallback(() => {
     navigate('/');

--- a/src/Pages/postDetailPage.js
+++ b/src/Pages/postDetailPage.js
@@ -200,13 +200,13 @@ const PostDetailPage = () => {
     ? new window.Date(postData.createdAt.seconds * 1000)
     : null;
 
-  const handleHamburgerClick = useCallback(() => {
+  const handleHamburgerClick = () => {
     setIsMenuOpen(!isMenuOpen);
-  }, []);
+  };
 
-  const handleEdit = useCallback(() => {
+  const handleEdit = () => {
     navigate(`/posts/${id}/edit`, { state: { id, postData } });
-  }, [id, postData]);
+  };
 
   const Toast = Swal.mixin({
     toast: true,
@@ -220,7 +220,7 @@ const PostDetailPage = () => {
     }
   });
 
-  const handleDelete = useCallback(async () => {
+  const handleDelete = async () => {
     try {
       const result = await Swal.fire({
         text: '정말로 이 게시글을 삭제하시겠습니까?',
@@ -252,17 +252,17 @@ const PostDetailPage = () => {
     } catch (error) {
       console.error('Error deleting post: ', error);
     }
-  }, []);
+  };
 
-  const handleGoBack = useCallback(() => {
+  const handleGoBack = () => {
     if (state && state.searchResult) {
       navigate('/search', { state: { searchResult: state.searchResult } });
     } else {
       navigate(-1);
     }
-  }, [state, navigate]);
+  };
 
-  const openModal = useCallback(async () => {
+  const openModal = async () => {
     const requestId = `${id}-${currentUserData.uuid}`;
     const docRef = doc(db, 'requests', requestId);
 
@@ -275,11 +275,11 @@ const PostDetailPage = () => {
     } else {
       setIsModalOpen(!isModalOpen);
     }
-  }, [isModalOpen]);
+  };
 
-  const closeModal = useCallback(async () => {
+  const closeModal = async () => {
     setIsModalOpen(!isModalOpen);
-  }, [isModalOpen]);
+  };
 
   const options = {
     month: '2-digit',

--- a/src/Pages/updatePostPage.js
+++ b/src/Pages/updatePostPage.js
@@ -58,9 +58,9 @@ const UpdatePostPage = () => {
     updatePost(state.postData.tags, postData)
   );
 
-  const handleChange = useCallback((e) => {
+  const handleChange = (e) => {
     setTitle(e.target.value);
-  }, []);
+  };
 
   const Toast = Swal.mixin({
     toast: true,
@@ -107,9 +107,9 @@ const UpdatePostPage = () => {
     }
   };
 
-  const handleGoBack = useCallback(() => {
+  const handleGoBack = () => {
     navigate(-1);
-  }, []);
+  };
 
   return (
     <PostSection>


### PR DESCRIPTION
1. 구현 기능
* 캐러셀 앞으로 가기, 뒤로 가기 버튼을 눌렀을 때 유저의 tagList에 있는 태그 순서대로 넘어가지 않는 이슈 해결(버튼 클릭시 tagIdx 변경 로직 수정)
* map key props 인덱스가 아닌 각 요소의 id 등 변동 없는 값으로 변경
* 불필요한 useCallback 제거
* 리렌더링 잦은 컴포넌트에 useMemo, useCallback 적용

2. 논의 사항
* 캐러셀 순서 이슈를 해결하였습니다.
 수정 전 코드는 캐러셀 라이브러리의 내부 로직을 간과한 채로 작성된 로직이여서 버튼을 눌러도 유저 태그 리스트 순서대로 뜨지 않는 문제가 있었습니다. 테스트는 태그를 최소 3개 이상 설정하신 후에 해보시면 됩니다. 
* 최적화를 위해 map key props를 인덱스가 아닌 각 요소의 id 등 변동 없는 값으로 변경하였습니다.
* 리렌더링이 잦을 것이라고 예상되는 컴포넌트에 useCallback 또는 useMemo를 적용시키고, 불필요한 useCallback 을 삭제하였습니다. useCallback의 올바른 사용에 대해 학습하고 스스로 고민해보는 시간을 충분히 가진 채 적용하였지만 아직 이 부분에 대한 이해도가 완벽하지 않은터라 수정된 코드 확인을 한 번 부탁드리고 싶습니다. 혹 불필요한 곳에 적용되었다고 판단되시는 부분이 있다면 댓글로 남겨주세요. 확인 후 수정하겠습니다.
