### PR TITLE
리액트 쿼리문 설정 및 캐러셀 컴포넌트 리팩토링 관련 PR 입니다.

### DIFF
--- a/src/Components/Chat/chatList.js
+++ b/src/Components/Chat/chatList.js
@@ -98,10 +98,6 @@ const ChatList = ({ setIsStarted }) => {
         console.error('Error fetching user data:', error);
         throw new Error('Failed to fetch chatroom data');
       }
-    },
-    {
-      refetchInterval: 500,
-      refetchIntervalInBackground: true
     }
   );
 

--- a/src/Components/Chat/requestList.js
+++ b/src/Components/Chat/requestList.js
@@ -91,28 +91,19 @@ const RequestList = () => {
     hour12: true
   };
 
-  const { data: requestData, isLoading } = useQuery(
-    'requestData',
-    async () => {
-      const { receivedRequests } = await getUserData(userId);
-      if (receivedRequests.length > 0) {
-        const requestPromises = receivedRequests.map((id) =>
-          getRequestById(id)
-        );
-        const requestList = await Promise.all(requestPromises);
+  const { data: requestData, isLoading } = useQuery('requestData', async () => {
+    const { receivedRequests } = await getUserData(userId);
+    if (receivedRequests.length > 0) {
+      const requestPromises = receivedRequests.map((id) => getRequestById(id));
+      const requestList = await Promise.all(requestPromises);
 
-        const sortedRequestList = requestList.sort(
-          (a, b) => b.createdAt.seconds - a.createdAt.seconds
-        );
+      const sortedRequestList = requestList.sort(
+        (a, b) => b.createdAt.seconds - a.createdAt.seconds
+      );
 
-        return sortedRequestList;
-      }
-    },
-    {
-      refetchInterval: 2000,
-      refetchIntervalInBackground: true
+      return sortedRequestList;
     }
-  );
+  });
 
   const handlerCloseModal = () => {
     setModalOpen(false);

--- a/src/Components/Post/carousel.js
+++ b/src/Components/Post/carousel.js
@@ -102,10 +102,6 @@ const Carousel = ({ tagList }) => {
       onSuccess: () => {
         setSavedCarouselData(carouselData);
       }
-    },
-    {
-      refetchInterval: 30000,
-      refetchIntervalInBackground: true
     }
   );
 

--- a/src/Components/Post/carousel.js
+++ b/src/Components/Post/carousel.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useRef, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -85,9 +85,9 @@ const GuideWrapper = styled.article`
     margin: 0px 0px 30px 0px;
   }
 `;
-
 const Carousel = ({ tagList }) => {
   const carouselRef = useRef(null);
+  const queryClient = useQueryClient();
 
   const [tagIdx, setTagIdx] = useState(0);
   const [savedCarouselData, setSavedCarouselData] = useState({});
@@ -101,7 +101,8 @@ const Carousel = ({ tagList }) => {
       enabled: tagList.length > 0,
       onSuccess: () => {
         setSavedCarouselData(carouselData);
-      }
+      },
+      initialData: queryClient.getQueryData(['carouselData', tagList[tagIdx]])
     }
   );
 
@@ -115,7 +116,7 @@ const Carousel = ({ tagList }) => {
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
-    initialSlide: 2,
+    initialSlide: tagIdx,
     arrows: true,
     beforeChange: (current, next) => {
       const carouselElement = carouselRef.current;
@@ -133,7 +134,7 @@ const Carousel = ({ tagList }) => {
 
   return (
     <>
-      {isLoading ? (
+      {isLoading || !carouselData ? (
         <SkeletonCarousel />
       ) : tagList.length > 0 ? (
         <CarouselWrapper>
@@ -156,7 +157,7 @@ const Carousel = ({ tagList }) => {
                       isSolved={post.isSolved}
                     />
                   ))}
-                {(!carouselData[tagList[tagIdx]] ||
+                {((!isLoading && !carouselData[tagList[tagIdx]]) ||
                   carouselData[tagList[tagIdx]].length === 0) && (
                   <GuideWrapper>
                     <p>현재 해당 태그에 게시물이 없습니다.</p>


### PR DESCRIPTION
1. 구현 기능
* 캐러셀, 리스트 데이터 GET 요청에 사용된 불필요 리액트 쿼리 설정 삭제(refetchInterval, refetchIntervalInBackground 등)
* 캐러셀 컴포넌트에 사용된 Slider 라이브러리 setting 변경

2. 논의 사항
* 캐러셀 컴포넌트 내부 슬라이더에서 tagIdx 배열 내 순서대로 게시글 리스트가 보이지 않던 현상, 가장 첫 요소로 돌아왔을 때 데이터가 refetch 되면서 잠시 스켈레톤 UI가 보이는 현상 등을 해결하기 위해 Slider 라이브러리의 setting을 변경하였습니다. 이제 캐러셀 컴포넌트가 버벅임 없이 더 부드럽고 깔끔하게 넘어간다는 느낌을 받을 수 있습니다.
* 서버 부하를 줄이기 위해 refetchInterval 설정을 지웠습니다. 이렇게 되면 더 이상 주식 앱처럼 빠르게 데이터가 업데이트 되진 않지만, 무한대로 늘어나는 네트워크 요청을 피할 수 있어 다음과 같이 변경해보았습니다. 이 방법이 최선인지에 대한 확신은 아직 없습니다. 꾸준히 알아보고 다양한 방법을 적용해보겠습니다.
